### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Dagobah
 
 <img src="http://i.imgur.com/D5ZxGXA.png" height="400">
 
-[![Build Status](https://travis-ci.org/thieman/dagobah.png?branch=master)](https://travis-ci.org/thieman/dagobah?branch=master) ![PyPi version](https://pypip.in/v/dagobah/badge.png)
+[![Build Status](https://travis-ci.org/thieman/dagobah.png?branch=master)](https://travis-ci.org/thieman/dagobah?branch=master) ![PyPi version](https://img.shields.io/pypi/v/dagobah.svg)
 
 Dagobah is a simple dependency-based job scheduler written in Python. Dagobah allows you to schedule periodic jobs using Cron syntax. Each job then kicks off a series of tasks (subprocesses) in an order defined by a dependency graph you can easily draw with click-and-drag in the web interface.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nagobah-with-server))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nagobah-with-server`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.